### PR TITLE
Stabilize embedded method ordering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicheinc/mock
 
-go 1.20
+go 1.21
 
 require (
 	github.com/pkg/errors v0.8.1

--- a/iface/get.go
+++ b/iface/get.go
@@ -140,12 +140,20 @@ func explodeInterface(iface *types.Interface) []*types.Interface {
 			visited[currentID] = true
 			result = append(result, current)
 			for i := 0; i < current.NumEmbeddeds(); i++ {
-				switch embeddedIface := current.EmbeddedType(i).(type) {
+				switch embedded := current.EmbeddedType(i).(type) {
 				case *types.Interface:
-					fmt.Printf("Found embedded interface %T\n", embeddedIface)
-					workQueue = append(workQueue, embeddedIface)
+					fmt.Printf("Found embedded interface %T\n", embedded)
+					workQueue = append(workQueue, embedded)
+				case *types.Named:
+					switch underlying := embedded.Underlying().(type) {
+					case *types.Interface:
+						fmt.Printf("Found named embedded interface %T\n", underlying)
+						workQueue = append(workQueue, underlying)
+					default:
+						fmt.Printf("Found non-interface named embedded type %T\n", underlying)
+					}
 				default:
-					fmt.Printf("Found embedded non-interface type %T\n", embeddedIface)
+					fmt.Printf("Found embedded non-interface type %T\n", embedded)
 				}
 			}
 		}

--- a/iface/get.go
+++ b/iface/get.go
@@ -77,9 +77,9 @@ func GetInterface(dir, ifaceName string) (Interface, error) {
 		for i := 0; i < ifaceType.NumExplicitMethods(); i++ {
 			methodObj := ifaceType.ExplicitMethod(i)
 			method := Method{
-				Name:            methodObj.Name(),
-				SourceInterface: ifaceType.String(),
-				pos:             methodObj.Pos(),
+				Name:     methodObj.Name(),
+				srcIface: ifaceType.String(),
+				pos:      methodObj.Pos(),
 			}
 
 			sig, ok := methodObj.Type().(*types.Signature)
@@ -142,18 +142,12 @@ func explodeInterface(iface *types.Interface) []*types.Interface {
 			for i := 0; i < current.NumEmbeddeds(); i++ {
 				switch embedded := current.EmbeddedType(i).(type) {
 				case *types.Interface:
-					fmt.Printf("Found embedded interface %T\n", embedded)
 					workQueue = append(workQueue, embedded)
 				case *types.Named:
 					switch underlying := embedded.Underlying().(type) {
 					case *types.Interface:
-						fmt.Printf("Found named embedded interface %T\n", underlying)
 						workQueue = append(workQueue, underlying)
-					default:
-						fmt.Printf("Found non-interface named embedded type %T\n", underlying)
 					}
-				default:
-					fmt.Printf("Found embedded non-interface type %T\n", embedded)
 				}
 			}
 		}

--- a/iface/get.go
+++ b/iface/get.go
@@ -77,7 +77,7 @@ func GetInterface(dir, ifaceName string) (Interface, error) {
 		methodObj := ifaceType.Method(i)
 		method := Method{
 			Name: methodObj.Name(),
-			pos:  methodObj.Pos(),
+			Pos:  methodObj.Pos(),
 		}
 
 		sig, ok := methodObj.Type().(*types.Signature)

--- a/iface/get.go
+++ b/iface/get.go
@@ -142,7 +142,10 @@ func explodeInterface(iface *types.Interface) []*types.Interface {
 			for i := 0; i < current.NumEmbeddeds(); i++ {
 				switch embeddedIface := current.EmbeddedType(i).(type) {
 				case *types.Interface:
+					fmt.Printf("Found embedded interface %T\n", embeddedIface)
 					workQueue = append(workQueue, embeddedIface)
+				default:
+					fmt.Printf("Found embedded non-interface type %T\n", embeddedIface)
 				}
 			}
 		}

--- a/iface/interface.go
+++ b/iface/interface.go
@@ -1,6 +1,7 @@
 package iface
 
 import (
+	"cmp"
 	"fmt"
 	"go/token"
 	"strings"
@@ -30,7 +31,7 @@ type Method struct {
 	Params  Params
 	Results Results
 
-	pos token.Pos
+	Pos token.Pos
 }
 
 type Methods []Method

--- a/iface/interface.go
+++ b/iface/interface.go
@@ -32,8 +32,8 @@ type Method struct {
 	Results Results
 
 	// String representation of the interface explicitly requiring this method
-	SourceInterface string
-	pos             token.Pos
+	srcIface string
+	pos      token.Pos
 }
 
 type Methods []Method
@@ -44,7 +44,7 @@ func (m Methods) Less(i, j int) bool {
 	// Group methods by source interface. This grouping matters when the mocked
 	// interface comprises interfaces defined in multiple files, in which case
 	// the token positions alone don't have a stable ordering.
-	switch cmp.Compare(m[i].SourceInterface, m[j].SourceInterface) {
+	switch cmp.Compare(m[i].srcIface, m[j].srcIface) {
 	case -1: // less
 		return true
 	case 1: // greater

--- a/iface/interface.go
+++ b/iface/interface.go
@@ -35,9 +35,22 @@ type Method struct {
 
 type Methods []Method
 
-func (m Methods) Len() int           { return len(m) }
-func (m Methods) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
-func (m Methods) Less(i, j int) bool { return m[i].pos < m[j].pos }
+func (m Methods) Len() int      { return len(m) }
+func (m Methods) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m Methods) Less(i, j int) bool {
+	switch cmp.Compare(m[i].Pos, m[j].Pos) {
+	case -1: // less
+		return true
+	case 1: // greater
+		return false
+	default: // equal
+		// This can happen when the mocked interface embeds one or more
+		// interfaces defined in other files. In that case, two different
+		// methods may have the same source position. Break any such ties using
+		// the method names.
+		return m[i].Name < m[j].Name
+	}
+}
 
 type Param struct {
 	Name     string

--- a/template.go
+++ b/template.go
@@ -23,7 +23,7 @@ var _ {{ .Name }} = &{{ .Name }}Mock{}
 
 // {{ .Name}} is a stub for the {{ $.Name }}.{{ .Name }}
 // method that records the number of times it has been called.
-func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{ // {{ .Pos }}
+func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{ // {{ .SourceInterface }}
 	atomic.AddInt32(&m.{{ .Name }}Called, 1) 
 	{{- if gt (len .Results) 0 }}
 	return m.{{ .Name }}Stub({{ .Params.ArgsString }})

--- a/template.go
+++ b/template.go
@@ -23,7 +23,7 @@ var _ {{ .Name }} = &{{ .Name }}Mock{}
 
 // {{ .Name}} is a stub for the {{ $.Name }}.{{ .Name }}
 // method that records the number of times it has been called.
-func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{
+func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{ // {{ .Pos }}
 	atomic.AddInt32(&m.{{ .Name }}Called, 1) 
 	{{- if gt (len .Results) 0 }}
 	return m.{{ .Name }}Stub({{ .Params.ArgsString }})

--- a/template.go
+++ b/template.go
@@ -23,7 +23,7 @@ var _ {{ .Name }} = &{{ .Name }}Mock{}
 
 // {{ .Name}} is a stub for the {{ $.Name }}.{{ .Name }}
 // method that records the number of times it has been called.
-func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{ // {{ .SourceInterface }}
+func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{
 	atomic.AddInt32(&m.{{ .Name }}Called, 1) 
 	{{- if gt (len .Results) 0 }}
 	return m.{{ .Name }}Stub({{ .Params.ArgsString }})


### PR DESCRIPTION
### Dependencies

None.

### Documentation

None.

### Description

`mock` currently [sorts methods by their source position](https://github.com/nicheinc/mock/blob/8b571bfe6d9e039e9de06141dbfc165c5c3f5451/iface/interface.go#L36-L40), which is reasonable - we want the mock to list its methods in the same order as the mocked interface. However, it turns out this doesn't consistently sort methods from embedded interfaces defined in multiple source files. If nothing else, inserting or deleting source text before a method could affect its order relative to methods defined in other source files, but I've observed that it's actually worse than that: a method's [`Pos()`](https://pkg.go.dev/go/types#Func.Pos) can change between invocations of `mock`, even without source code changes. I think that's because [`token.Pos`](https://pkg.go.dev/go/token#Pos) includes a "base" value that depends on the (arbitrary) order different files are added to the "file set":

> The Pos value for a given file is a number in the range [base, base+size], where base and size are specified when a file is added to the file set.

This PR stabilizes the order of generated methods, first sorting methods by the interface that requires them[^1] and then by source position.

[^1]: Technically, by the _first_ interface explicitly requiring that method encountered during traversal of the embedded interfaces. The same method could be required by multiple interfaces.

### Testing Considerations

I noticed this while working in `survey`, which has several interfaces with mock generation directives that produce unstable output. Most noticeably, [`SurveyStore`](https://github.com/nicheinc/survey/blob/cf32a54c50cc63eb8aad2697a5912a7ae7a3da38/internal/postgres/surveyStore.go#L16-L29) almost always changes when rerunning `go generate ./...` because it embeds eight other interfaces, from various source files. So the easiest way to test this fix is to edit [the `go:generate` directive](https://github.com/nicheinc/survey/blob/cf32a54c50cc63eb8aad2697a5912a7ae7a3da38/internal/postgres/surveyStore.go#L16) to use `github.com/nicheinc/mock@fix/embedded-method-ordering` instead of `github.com/nicheinc/mock@main` and then run `go generate ./...` a bunch of times, confirming that after the initial reordering, the file doesn't keep changing.

### Versioning

`main`
