### PR TITLE
Don't include doubly-embedded methods more than once

### DIFF
--- a/examples/directive/example.go
+++ b/examples/directive/example.go
@@ -82,4 +82,19 @@ type Example interface {
 	})
 	ChannelReturn() chan int
 	MapReturn() map[int]int
+
+	// EmbeddedA and EmbeddedB both provide SharedMethod(), which should be
+	// included in ExampleMock only once.
+	EmbeddedA
+	EmbeddedB
+}
+
+type EmbeddedA interface {
+	SharedMethod()
+	MethodA()
+}
+
+type EmbeddedB interface {
+	SharedMethod()
+	MethodB()
 }

--- a/examples/directive/example_mock.go
+++ b/examples/directive/example_mock.go
@@ -107,6 +107,12 @@ type ExampleMock struct {
 	ChannelReturnCalled                      int32
 	MapReturnStub                            func() map[int]int
 	MapReturnCalled                          int32
+	SharedMethodStub                         func()
+	SharedMethodCalled                       int32
+	MethodAStub                              func()
+	MethodACalled                            int32
+	MethodBStub                              func()
+	MethodBCalled                            int32
 }
 
 // Verify that *ExampleMock implements Example.
@@ -708,4 +714,43 @@ func (m *ExampleMock) MapReturn() map[int]int {
 		panic("MapReturn unimplemented")
 	}
 	return m.MapReturnStub()
+}
+
+// SharedMethod is a stub for the Example.SharedMethod
+// method that records the number of times it has been called.
+func (m *ExampleMock) SharedMethod() {
+	atomic.AddInt32(&m.SharedMethodCalled, 1)
+	if m.SharedMethodStub == nil {
+		if m.T != nil {
+			m.T.Error("SharedMethodStub is nil")
+		}
+		panic("SharedMethod unimplemented")
+	}
+	m.SharedMethodStub()
+}
+
+// MethodA is a stub for the Example.MethodA
+// method that records the number of times it has been called.
+func (m *ExampleMock) MethodA() {
+	atomic.AddInt32(&m.MethodACalled, 1)
+	if m.MethodAStub == nil {
+		if m.T != nil {
+			m.T.Error("MethodAStub is nil")
+		}
+		panic("MethodA unimplemented")
+	}
+	m.MethodAStub()
+}
+
+// MethodB is a stub for the Example.MethodB
+// method that records the number of times it has been called.
+func (m *ExampleMock) MethodB() {
+	atomic.AddInt32(&m.MethodBCalled, 1)
+	if m.MethodBStub == nil {
+		if m.T != nil {
+			m.T.Error("MethodBStub is nil")
+		}
+		panic("MethodB unimplemented")
+	}
+	m.MethodBStub()
 }

--- a/examples/generate/example.go
+++ b/examples/generate/example.go
@@ -82,4 +82,19 @@ type Example interface {
 	})
 	ChannelReturn() chan int
 	MapReturn() map[int]int
+
+	// EmbeddedA and EmbeddedB both provide SharedMethod(), which should be
+	// included in ExampleMock only once.
+	EmbeddedA
+	EmbeddedB
+}
+
+type EmbeddedA interface {
+	SharedMethod()
+	MethodA()
+}
+
+type EmbeddedB interface {
+	SharedMethod()
+	MethodB()
 }

--- a/examples/generate/example_mock.go
+++ b/examples/generate/example_mock.go
@@ -107,6 +107,12 @@ type ExampleMock struct {
 	ChannelReturnCalled                      int32
 	MapReturnStub                            func() map[int]int
 	MapReturnCalled                          int32
+	SharedMethodStub                         func()
+	SharedMethodCalled                       int32
+	MethodAStub                              func()
+	MethodACalled                            int32
+	MethodBStub                              func()
+	MethodBCalled                            int32
 }
 
 // Verify that *ExampleMock implements Example.
@@ -708,4 +714,43 @@ func (m *ExampleMock) MapReturn() map[int]int {
 		panic("MapReturn unimplemented")
 	}
 	return m.MapReturnStub()
+}
+
+// SharedMethod is a stub for the Example.SharedMethod
+// method that records the number of times it has been called.
+func (m *ExampleMock) SharedMethod() {
+	atomic.AddInt32(&m.SharedMethodCalled, 1)
+	if m.SharedMethodStub == nil {
+		if m.T != nil {
+			m.T.Error("SharedMethodStub is nil")
+		}
+		panic("SharedMethod unimplemented")
+	}
+	m.SharedMethodStub()
+}
+
+// MethodA is a stub for the Example.MethodA
+// method that records the number of times it has been called.
+func (m *ExampleMock) MethodA() {
+	atomic.AddInt32(&m.MethodACalled, 1)
+	if m.MethodAStub == nil {
+		if m.T != nil {
+			m.T.Error("MethodAStub is nil")
+		}
+		panic("MethodA unimplemented")
+	}
+	m.MethodAStub()
+}
+
+// MethodB is a stub for the Example.MethodB
+// method that records the number of times it has been called.
+func (m *ExampleMock) MethodB() {
+	atomic.AddInt32(&m.MethodBCalled, 1)
+	if m.MethodBStub == nil {
+		if m.T != nil {
+			m.T.Error("MethodBStub is nil")
+		}
+		panic("MethodB unimplemented")
+	}
+	m.MethodBStub()
 }

--- a/iface/get.go
+++ b/iface/get.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/types"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -232,7 +233,9 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 				method.Results = append(method.Results, result)
 			}
 
-			iface.Methods = append(iface.Methods, method)
+			if !slices.ContainsFunc(iface.Methods, method.Equal) {
+				iface.Methods = append(iface.Methods, method)
+			}
 		}
 	}
 

--- a/iface/interface.go
+++ b/iface/interface.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"go/token"
+	"reflect"
 	"strings"
 )
 
@@ -74,6 +75,12 @@ type Method struct {
 	// String representation of the interface explicitly requiring this method
 	srcIface string
 	pos      token.Pos
+}
+
+func (m Method) Equal(other Method) bool {
+	return m.Name == other.Name &&
+		reflect.DeepEqual(m.Params, other.Params) &&
+		reflect.DeepEqual(m.Results, other.Results)
 }
 
 type Methods []Method


### PR DESCRIPTION
### Description

This fixes a bug where `mock` would generate the same method name twice if that method is embedded via two different interfaces, causing the generated mock not to compile.

### Testing Considerations

I've added new methods to the test interfaces in `examples` to exercise this behavior. These can't be mocked correctly on `main` but can on this branch. This can also be tested in `inventory`, where I noticed this problem.

### Versioning

Patch.
