### PR TITLE
Detect alias type params

### DIFF
--- a/examples/directive/example.go
+++ b/examples/directive/example.go
@@ -40,8 +40,8 @@ type Example interface {
 	StructVariadicParam(objs ...struct{ num int })
 	EmbeddedStructParam(obj struct{ int })
 	EmbeddedStructVariadicParam(objs ...struct{ int })
-	EmptyInterfaceParam(intf interface{})
-	EmptyInterfaceVariadicParam(intf ...interface{})
+	EmptyInterfaceParam(intf any)
+	EmptyInterfaceVariadicParam(intf ...any)
 	InterfaceParam(intf interface {
 		MyFunc(num int) error
 	})
@@ -70,7 +70,7 @@ type Example interface {
 	SelfReferentialReturn() (intf Example)
 	StructReturn() (obj struct{ num int })
 	EmbeddedStructReturn() (obj struct{ int })
-	EmptyInterfaceReturn() (intf interface{})
+	EmptyInterfaceReturn() (intf any)
 	InterfaceReturn() (intf interface {
 		MyFunc(num int) error
 	})

--- a/examples/directive/example_mock.go
+++ b/examples/directive/example_mock.go
@@ -57,9 +57,9 @@ type ExampleMock struct {
 	EmbeddedStructParamCalled                int32
 	EmbeddedStructVariadicParamStub          func(objs ...struct{ int })
 	EmbeddedStructVariadicParamCalled        int32
-	EmptyInterfaceParamStub                  func(intf interface{})
+	EmptyInterfaceParamStub                  func(intf any)
 	EmptyInterfaceParamCalled                int32
-	EmptyInterfaceVariadicParamStub          func(intf ...interface{})
+	EmptyInterfaceVariadicParamStub          func(intf ...any)
 	EmptyInterfaceVariadicParamCalled        int32
 	InterfaceParamStub                       func(intf interface{ MyFunc(num int) error })
 	InterfaceParamCalled                     int32
@@ -95,7 +95,7 @@ type ExampleMock struct {
 	StructReturnCalled                       int32
 	EmbeddedStructReturnStub                 func() (obj struct{ int })
 	EmbeddedStructReturnCalled               int32
-	EmptyInterfaceReturnStub                 func() (intf interface{})
+	EmptyInterfaceReturnStub                 func() (intf any)
 	EmptyInterfaceReturnCalled               int32
 	InterfaceReturnStub                      func() (intf interface{ MyFunc(num int) error })
 	InterfaceReturnCalled                    int32
@@ -393,7 +393,7 @@ func (m *ExampleMock) EmbeddedStructVariadicParam(objs ...struct{ int }) {
 
 // EmptyInterfaceParam is a stub for the Example.EmptyInterfaceParam
 // method that records the number of times it has been called.
-func (m *ExampleMock) EmptyInterfaceParam(intf interface{}) {
+func (m *ExampleMock) EmptyInterfaceParam(intf any) {
 	atomic.AddInt32(&m.EmptyInterfaceParamCalled, 1)
 	if m.EmptyInterfaceParamStub == nil {
 		if m.T != nil {
@@ -406,7 +406,7 @@ func (m *ExampleMock) EmptyInterfaceParam(intf interface{}) {
 
 // EmptyInterfaceVariadicParam is a stub for the Example.EmptyInterfaceVariadicParam
 // method that records the number of times it has been called.
-func (m *ExampleMock) EmptyInterfaceVariadicParam(intf ...interface{}) {
+func (m *ExampleMock) EmptyInterfaceVariadicParam(intf ...any) {
 	atomic.AddInt32(&m.EmptyInterfaceVariadicParamCalled, 1)
 	if m.EmptyInterfaceVariadicParamStub == nil {
 		if m.T != nil {
@@ -640,7 +640,7 @@ func (m *ExampleMock) EmbeddedStructReturn() (obj struct{ int }) {
 
 // EmptyInterfaceReturn is a stub for the Example.EmptyInterfaceReturn
 // method that records the number of times it has been called.
-func (m *ExampleMock) EmptyInterfaceReturn() (intf interface{}) {
+func (m *ExampleMock) EmptyInterfaceReturn() (intf any) {
 	atomic.AddInt32(&m.EmptyInterfaceReturnCalled, 1)
 	if m.EmptyInterfaceReturnStub == nil {
 		if m.T != nil {

--- a/examples/directive/generic.go
+++ b/examples/directive/generic.go
@@ -9,3 +9,8 @@ type Generic[T interface{ byte | internal.Internal }, U any] interface {
 	GetT() T
 	GetU() U
 }
+
+// GenericAlias is an alias of [Generic].
+//
+//go:mock
+type GenericAlias[T interface{ byte | internal.Internal }, U any] = Generic[T, U]

--- a/examples/generate/example.go
+++ b/examples/generate/example.go
@@ -40,8 +40,8 @@ type Example interface {
 	StructVariadicParam(objs ...struct{ num int })
 	EmbeddedStructParam(obj struct{ int })
 	EmbeddedStructVariadicParam(objs ...struct{ int })
-	EmptyInterfaceParam(intf interface{})
-	EmptyInterfaceVariadicParam(intf ...interface{})
+	EmptyInterfaceParam(intf any)
+	EmptyInterfaceVariadicParam(intf ...any)
 	InterfaceParam(intf interface {
 		MyFunc(num int) error
 	})
@@ -70,7 +70,7 @@ type Example interface {
 	SelfReferentialReturn() (intf Example)
 	StructReturn() (obj struct{ num int })
 	EmbeddedStructReturn() (obj struct{ int })
-	EmptyInterfaceReturn() (intf interface{})
+	EmptyInterfaceReturn() (intf any)
 	InterfaceReturn() (intf interface {
 		MyFunc(num int) error
 	})

--- a/examples/generate/example_mock.go
+++ b/examples/generate/example_mock.go
@@ -57,9 +57,9 @@ type ExampleMock struct {
 	EmbeddedStructParamCalled                int32
 	EmbeddedStructVariadicParamStub          func(objs ...struct{ int })
 	EmbeddedStructVariadicParamCalled        int32
-	EmptyInterfaceParamStub                  func(intf interface{})
+	EmptyInterfaceParamStub                  func(intf any)
 	EmptyInterfaceParamCalled                int32
-	EmptyInterfaceVariadicParamStub          func(intf ...interface{})
+	EmptyInterfaceVariadicParamStub          func(intf ...any)
 	EmptyInterfaceVariadicParamCalled        int32
 	InterfaceParamStub                       func(intf interface{ MyFunc(num int) error })
 	InterfaceParamCalled                     int32
@@ -95,7 +95,7 @@ type ExampleMock struct {
 	StructReturnCalled                       int32
 	EmbeddedStructReturnStub                 func() (obj struct{ int })
 	EmbeddedStructReturnCalled               int32
-	EmptyInterfaceReturnStub                 func() (intf interface{})
+	EmptyInterfaceReturnStub                 func() (intf any)
 	EmptyInterfaceReturnCalled               int32
 	InterfaceReturnStub                      func() (intf interface{ MyFunc(num int) error })
 	InterfaceReturnCalled                    int32
@@ -393,7 +393,7 @@ func (m *ExampleMock) EmbeddedStructVariadicParam(objs ...struct{ int }) {
 
 // EmptyInterfaceParam is a stub for the Example.EmptyInterfaceParam
 // method that records the number of times it has been called.
-func (m *ExampleMock) EmptyInterfaceParam(intf interface{}) {
+func (m *ExampleMock) EmptyInterfaceParam(intf any) {
 	atomic.AddInt32(&m.EmptyInterfaceParamCalled, 1)
 	if m.EmptyInterfaceParamStub == nil {
 		if m.T != nil {
@@ -406,7 +406,7 @@ func (m *ExampleMock) EmptyInterfaceParam(intf interface{}) {
 
 // EmptyInterfaceVariadicParam is a stub for the Example.EmptyInterfaceVariadicParam
 // method that records the number of times it has been called.
-func (m *ExampleMock) EmptyInterfaceVariadicParam(intf ...interface{}) {
+func (m *ExampleMock) EmptyInterfaceVariadicParam(intf ...any) {
 	atomic.AddInt32(&m.EmptyInterfaceVariadicParamCalled, 1)
 	if m.EmptyInterfaceVariadicParamStub == nil {
 		if m.T != nil {
@@ -640,7 +640,7 @@ func (m *ExampleMock) EmbeddedStructReturn() (obj struct{ int }) {
 
 // EmptyInterfaceReturn is a stub for the Example.EmptyInterfaceReturn
 // method that records the number of times it has been called.
-func (m *ExampleMock) EmptyInterfaceReturn() (intf interface{}) {
+func (m *ExampleMock) EmptyInterfaceReturn() (intf any) {
 	atomic.AddInt32(&m.EmptyInterfaceReturnCalled, 1)
 	if m.EmptyInterfaceReturnStub == nil {
 		if m.T != nil {

--- a/examples/generate/generic.go
+++ b/examples/generate/generic.go
@@ -9,3 +9,8 @@ type Generic[T interface{ byte | internal.Internal }, U any] interface {
 	GetT() T
 	GetU() U
 }
+
+// GenericAlias is an alias of [Generic].
+//
+//go:generate mock -o genericAlias_mock.go GenericAlias
+type GenericAlias[T interface{ byte | internal.Internal }, U any] = Generic[T, U]

--- a/examples/generate/genericAlias_mock.go
+++ b/examples/generate/genericAlias_mock.go
@@ -1,52 +1,11 @@
-package directive
+package generate
 
 import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/nicheinc/mock/examples/directive/internal"
+	"github.com/nicheinc/mock/examples/generate/internal"
 )
-
-// GenericMock is a mock implementation of the Generic
-// interface.
-type GenericMock[T interface{ byte | internal.Internal }, U any] struct {
-	T          *testing.T
-	GetTStub   func() T
-	GetTCalled int32
-	GetUStub   func() U
-	GetUCalled int32
-}
-
-// Verify that *GenericMock implements Generic.
-func _[T interface{ byte | internal.Internal }, U any]() {
-	var _ Generic[T, U] = &GenericMock[T, U]{}
-}
-
-// GetT is a stub for the Generic.GetT
-// method that records the number of times it has been called.
-func (m *GenericMock[T, U]) GetT() T {
-	atomic.AddInt32(&m.GetTCalled, 1)
-	if m.GetTStub == nil {
-		if m.T != nil {
-			m.T.Error("GetTStub is nil")
-		}
-		panic("GetT unimplemented")
-	}
-	return m.GetTStub()
-}
-
-// GetU is a stub for the Generic.GetU
-// method that records the number of times it has been called.
-func (m *GenericMock[T, U]) GetU() U {
-	atomic.AddInt32(&m.GetUCalled, 1)
-	if m.GetUStub == nil {
-		if m.T != nil {
-			m.T.Error("GetUStub is nil")
-		}
-		panic("GetU unimplemented")
-	}
-	return m.GetUStub()
-}
 
 // GenericAliasMock is a mock implementation of the GenericAlias
 // interface.

--- a/iface/get.go
+++ b/iface/get.go
@@ -267,8 +267,7 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 	iface := Interface{Name: object.Name()}
 
 	// Record type parameter list info.
-	if ifaceNamed, ok := object.Type().(*types.Named); ok {
-		typeParams := ifaceNamed.TypeParams()
+	if typeParams := getTypeParams(object.Type()); typeParams != nil {
 		for i := range typeParams.Len() {
 			typeParam := typeParams.At(i)
 			iface.TypeParams = append(iface.TypeParams, TypeParam{
@@ -330,6 +329,18 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 	sort.Sort(iface.Methods)
 
 	return iface, nil
+}
+
+// getTypeParams returns type parameter list info for named types and aliases.
+// It returns nil for all other types.
+func getTypeParams(typ types.Type) *types.TypeParamList {
+	switch typ := typ.(type) {
+	case *types.Named:
+		return typ.TypeParams()
+	case *types.Alias:
+		return typ.TypeParams()
+	}
+	return nil
 }
 
 // explodeInterface traverses an interface type, returning the original

--- a/iface/get.go
+++ b/iface/get.go
@@ -268,8 +268,7 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 
 	// Record type parameter list info.
 	if typeParams := getTypeParams(object.Type()); typeParams != nil {
-		for i := range typeParams.Len() {
-			typeParam := typeParams.At(i)
+		for typeParam := range typeParams.TypeParams() {
 			iface.TypeParams = append(iface.TypeParams, TypeParam{
 				Name:       typeParam.Obj().Name(),
 				Constraint: types.TypeString(typeParam.Constraint(), qualifier),
@@ -279,8 +278,7 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 
 	// Iterate through each embedded interface's explicit methods.
 	for _, ifaceType := range explodeInterface(ifaceType) {
-		for i := range ifaceType.NumExplicitMethods() {
-			methodObj := ifaceType.ExplicitMethod(i)
+		for methodObj := range ifaceType.ExplicitMethods() {
 			method := Method{
 				Name:     methodObj.Name(),
 				srcIface: ifaceType.String(),
@@ -293,9 +291,7 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 			}
 
 			// Keep track of the names and types of the parameters.
-			paramsTuple := sig.Params()
-			for j := 0; j < paramsTuple.Len(); j++ {
-				paramObj := paramsTuple.At(j)
+			for paramObj := range sig.Params().Variables() {
 				param := Param{
 					Name: paramObj.Name(),
 					Type: types.TypeString(paramObj.Type(), qualifier),
@@ -309,9 +305,7 @@ func getInterface(fileInfo fileInfo, qualifier types.Qualifier, object types.Obj
 			}
 
 			// Keep track of the names and types of the results.
-			resultsTuple := sig.Results()
-			for j := 0; j < resultsTuple.Len(); j++ {
-				resultObj := resultsTuple.At(j)
+			for resultObj := range sig.Results().Variables() {
 				result := Result{
 					Name: resultObj.Name(),
 					Type: types.TypeString(resultObj.Type(), qualifier),
@@ -358,8 +352,8 @@ func explodeInterface(iface *types.Interface) []*types.Interface {
 		if !visited[currentID] {
 			visited[currentID] = true
 			result = append(result, current)
-			for i := range current.NumEmbeddeds() {
-				switch embedded := current.EmbeddedType(i).(type) {
+			for embedded := range current.EmbeddedTypes() {
+				switch embedded := embedded.(type) {
 				case *types.Interface:
 					workQueue = append(workQueue, embedded)
 				case *types.Named:
@@ -456,8 +450,8 @@ func validateType(typ types.Type, visited map[types.Type]bool) bool {
 		return validateType(t.Elem(), visited)
 
 	case *types.Struct:
-		for i := range t.NumFields() {
-			if !validateType(t.Field(i).Type(), visited) {
+		for field := range t.Fields() {
+			if !validateType(field.Type(), visited) {
 				return false
 			}
 		}
@@ -467,8 +461,8 @@ func validateType(typ types.Type, visited map[types.Type]bool) bool {
 		return validateType(t.Elem(), visited)
 
 	case *types.Tuple:
-		for i := range t.Len() {
-			if !validateType(t.At(i).Type(), visited) {
+		for variable := range t.Variables() {
+			if !validateType(variable.Type(), visited) {
 				return false
 			}
 		}
@@ -479,21 +473,21 @@ func validateType(typ types.Type, visited map[types.Type]bool) bool {
 			validateType(t.Results(), visited)
 
 	case *types.Interface:
-		for i := range t.NumEmbeddeds() {
-			if !validateType(t.EmbeddedType(i), visited) {
+		for embedded := range t.EmbeddedTypes() {
+			if !validateType(embedded, visited) {
 				return false
 			}
 		}
-		for i := range t.NumMethods() {
-			if !validateType(t.Method(i).Type(), visited) {
+		for method := range t.Methods() {
+			if !validateType(method.Type(), visited) {
 				return false
 			}
 		}
 		return true
 
 	case *types.Union:
-		for i := range t.Len() {
-			if !validateType(t.Term(i).Type(), visited) {
+		for term := range t.Terms() {
+			if !validateType(term.Type(), visited) {
 				return false
 			}
 		}
@@ -507,9 +501,8 @@ func validateType(typ types.Type, visited map[types.Type]bool) bool {
 		return validateType(t.Elem(), visited)
 
 	case *types.Named:
-		typeParams := t.TypeParams()
-		for i := range typeParams.Len() {
-			if !validateType(typeParams.At(i).Constraint(), visited) {
+		for typeParam := range t.TypeParams().TypeParams() {
+			if !validateType(typeParam.Constraint(), visited) {
 				return false
 			}
 		}


### PR DESCRIPTION
### Description

This fixes a bug that would cause the mocks generated for type aliases not to include type parameters in the mock's type-checking variable assignment. For example, the following type alias...

```go
//go:mock
type GenericAlias[T any] = Generic[T]
```

...would produce the following mock, which doesn't compile because the type params are missing:

```go
var _ GenericAlias = &GenericAliasMock{}
```

`mock` will now correctly produce the following, similar to what it already did for named generic types:

```go
func _[T any]() {
	var _ GenericAlias[T] = &GenericAliasMock[T]{}
}
```

This PR also runs `go fix ./...` on the module to modernize some for-loops to use iterators and switch `interface{}` to `any`.

### Testing Considerations

Coverage added to the example mocks.

### Versioning

Patch.